### PR TITLE
Add simple Highcharts demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Highcharts Stock Test
+
+This repository contains a simple demo implementing the requirements from the technical document.
+
+The `web` folder hosts a small React based page that renders a candlestick chart using **Highcharts**. It includes:
+
+- Ticker input with two dummy symbols (`AAPL` and `GOOG`).
+- Ability to toggle four predefined SMA lines (10, 20, 50 and 100).
+- Random OHLCV data for one year for each symbol.
+- Responsive behaviour and dynamic redraw when options are changed.
+
+Open `web/index.html` in a browser to try the demo.

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,103 @@
+const { useState, useEffect, useRef } = React;
+
+function generateData(points) {
+  const data = [];
+  const volumes = [];
+  let price = 100;
+  for (let i = 0; i < points; i++) {
+    const open = price + (Math.random() - 0.5) * 2;
+    const close = open + (Math.random() - 0.5) * 2;
+    const high = Math.max(open, close) + Math.random();
+    const low = Math.min(open, close) - Math.random();
+    const time = Date.UTC(2023, 0, i + 1);
+    data.push([time, open.toFixed(2) * 1, high.toFixed(2) * 1, low.toFixed(2) * 1, close.toFixed(2) * 1]);
+    volumes.push([time, Math.round(Math.random() * 1000 + 100)]);
+    price = close;
+  }
+  return { ohlc: data, volume: volumes };
+}
+
+const datasets = {
+  AAPL: generateData(365),
+  GOOG: generateData(365)
+};
+
+function App() {
+  const [ticker, setTicker] = useState('AAPL');
+  const [smas, setSmas] = useState({10: false, 20: false, 50: false, 100: false});
+  const chartRef = useRef(null);
+
+  const redraw = () => {
+    const data = datasets[ticker];
+    const series = [
+      {
+        type: 'candlestick',
+        id: 'ohlc',
+        name: ticker,
+        data: data.ohlc
+      },
+      {
+        type: 'column',
+        id: 'volume',
+        name: 'Volume',
+        data: data.volume,
+        yAxis: 1
+      }
+    ];
+    Object.keys(smas).forEach(period => {
+      if (smas[period]) {
+        series.push({
+          type: 'sma',
+          linkedTo: 'ohlc',
+          name: `SMA ${period}`,
+          params: { period: Number(period) }
+        });
+      }
+    });
+
+    if (chartRef.current) {
+      chartRef.current.destroy();
+    }
+
+    chartRef.current = Highcharts.stockChart('chart', {
+      rangeSelector: { selected: 5 },
+      title: { text: ticker + ' Stock Price' },
+      yAxis: [{ labels: { align: 'right', x: -3 }, title: { text: 'Price' }, height: '60%', resize: { enabled: true } }, { labels: { align: 'right', x: -3 }, title: { text: 'Volume' }, top: '65%', height: '35%', offset: 0 }],
+      tooltip: { split: false },
+      series
+    });
+  };
+
+  useEffect(() => { redraw(); }, [ticker, smas]);
+
+  const handleSmaChange = (period) => {
+    setSmas(prev => ({ ...prev, [period]: !prev[period] }));
+  };
+
+  return (
+    React.createElement('div', null,
+      React.createElement('div', { className: 'controls' },
+        React.createElement('label', null, 'Ticker:',
+          React.createElement('input', { value: ticker, onChange: e => setTicker(e.target.value.toUpperCase()), list: 'tickers' })),
+        React.createElement('datalist', { id: 'tickers' },
+          Object.keys(datasets).map(key => React.createElement('option', { key }, key))
+        ),
+        React.createElement('div', { className: 'sma-list' },
+          Object.keys(smas).map(period => (
+            React.createElement('label', { key: period },
+              React.createElement('input', {
+                type: 'checkbox',
+                checked: smas[period],
+                onChange: () => handleSmaChange(period)
+              }),
+              ` SMA ${period}`
+            )
+          ))
+        )
+      ),
+      React.createElement('div', { id: 'chart' })
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(React.createElement(App));

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stock Chart Test</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://code.highcharts.com/stock/highstock.js"></script>
+  <script src="https://code.highcharts.com/stock/indicators/indicators-all.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    #chart { height: 500px; }
+    .controls { margin-bottom: 20px; }
+    .sma-list label { margin-right: 10px; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small React/Highcharts demo implementing the technical chart requirements
- document usage in `README.md`

## Testing
- `grep -o '<w:t[^>]*>[^<]*</w:t>' docx/word/document.xml | sed -e 's/<[^>]*>//g' | sed 's/^\s\+//' | sed 's/\s\+$//' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68792312fbf4832ca2f8f257e88b5074