### PR TITLE
Serve web folder and use bundled libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install
 npm start
 ```
 
-This runs [http-server](https://www.npmjs.com/package/http-server) at <http://localhost:8000>. Open <http://localhost:8000/web/> in your browser to see the chart. On Windows open *Command Prompt* or *PowerShell*, navigate to the project folder and run the same commands.
+This runs [http-server](https://www.npmjs.com/package/http-server) at <http://localhost:8000>. Open <http://localhost:8000> in your browser to see the chart. On Windows open *Command Prompt* or *PowerShell*, navigate to the project folder and run the same commands.
 
 Because the site is completely static you can host it for free. Two options:
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "http-server . -p 8000"
+    "start": "http-server web -p 8000"
   },
   "keywords": [],
   "author": "",

--- a/web/index.html
+++ b/web/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Stock Chart Test</title>
-  <script src="../node_modules/react/umd/react.development.js"></script>
-  <script src="../node_modules/react-dom/umd/react-dom.development.js"></script>
-  <script src="../node_modules/highcharts/highstock.js"></script>
-  <script src="../node_modules/highcharts/indicators/indicators-all.js"></script>
+  <script src="lib/react.js"></script>
+  <script src="lib/react-dom.js"></script>
+  <script src="lib/highstock.js"></script>
+  <script src="lib/indicators-all.js"></script>
 
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }


### PR DESCRIPTION
## Summary
- serve the `web` folder directly so `/` loads the demo
- reference the local `lib/` copies of React and Highcharts
- update README instructions

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687935bb5934832cac18cd92e5500277