### PR TITLE
Enhance chart interactivity and layout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,16 +11,23 @@
 
   <style>
     body {
-  font-family: Arial, sans-serif;
-  background: #f5f5f5;
-  padding: 20px;
-}
-#chart {
-  height: 500px;
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-}
+      font-family: Arial, sans-serif;
+      background: #f5f5f5;
+      margin: 0;
+      padding: 20px;
+      height: 100vh;
+      box-sizing: border-box;
+    }
+    #app {
+      position: relative;
+      height: 100%;
+    }
+    #chart {
+      height: 70vh;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    }
 .controls {
   margin: 20px 0;
 }
@@ -39,8 +46,8 @@
 }
 .sma-legend {
   position: absolute;
-  top: 90px;
-  right: 40px;
+  top: 20px;
+  right: 20px;
   background: #fff;
   padding: 10px;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- redesign chart layout to use full page height
- keep chart instance while toggling SMA indicators
- draw volume behind the candlesticks
- assign colors to SMA legend items
- generate data for unknown tickers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a69259b9c832cb81cbf83563aa297