### PR TITLE
Improve chart layout and SMA logic

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -75,6 +75,12 @@ function App() {
       chart: { backgroundColor: '#fff' },
       rangeSelector: { selected: 4, inputDateFormat: '%Y-%m-%d' },
       title: { text: ticker + ' Stock Price' },
+      plotOptions: {
+        series: {
+          marker: { enabled: false },
+          states: { hover: { enabled: false } }
+        }
+      },
       yAxis: [
         {
           labels: { align: 'right', x: -3 },
@@ -127,6 +133,7 @@ function App() {
   const updateSmas = () => {
     const chart = chartRef.current;
     if (!chart) return;
+    let changed = false;
     Object.keys(smas).forEach(period => {
       const id = `sma-${period}`;
       const existing = chart.get(id);
@@ -141,12 +148,14 @@ function App() {
             color: smaColors[period],
             marker: { enabled: false }
           }, false);
+          changed = true;
         }
       } else if (existing) {
         existing.remove(false);
+        changed = true;
       }
     });
-    chart.redraw();
+    if (changed) chart.redraw();
   };
 
   useEffect(() => { initChart(); }, [ticker]);

--- a/web/index.html
+++ b/web/index.html
@@ -14,29 +14,38 @@
       font-family: Arial, sans-serif;
       background: #f5f5f5;
       margin: 0;
-      padding: 20px;
+      padding: 0;
       height: 100vh;
-      box-sizing: border-box;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
     #app {
       position: relative;
-      height: 100%;
+      display: flex;
+      flex-direction: column;
+      height: 95vh;
+      width: 95vw;
     }
     #chart {
-      height: 70vh;
+      flex: 1;
       background: white;
       border-radius: 8px;
       box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
     }
 .controls {
-  margin: 20px 0;
+  margin-bottom: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
 }
 .chart-header {
   display: flex;
   justify-content: space-between;
   font-size: 18px;
   font-weight: bold;
-  padding: 10px 0;
+  margin-bottom: 10px;
 }
 .chart-header .price-info span {
   margin-left: 12px;
@@ -46,13 +55,14 @@
 }
 .sma-legend {
   position: absolute;
-  top: 20px;
-  right: 20px;
+  top: 10px;
+  right: 10px;
   background: #fff;
-  padding: 10px;
+  padding: 8px;
   border-radius: 6px;
   border: 1px solid #ccc;
   box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  z-index: 10;
 }
 .legend-item {
   display: flex;


### PR DESCRIPTION
## Summary
- update CSS for a full page layout and visible SMA legend
- disable markers globally and only redraw chart when SMA state changes

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687a6b5c391c832cb68bdd9e30861039